### PR TITLE
mysql类型格式化增加数字值判断

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "description": "microservice framework base on swoole",
     "license": "Apache-2.0",
     "require": {
+        "php": ">=7.0",
         "ext-pdo": "*",
         "swoft/framework": "^1.0.15",
         "swoft/console": "^1.0",

--- a/src/Driver/Mysql/MysqlConnection.php
+++ b/src/Driver/Mysql/MysqlConnection.php
@@ -238,6 +238,8 @@ class MysqlConnection extends AbstractDbConnection
         foreach ($params as $key => $value) {
             if ($value === null) {
                 $value = " null ";
+            } else if (\is_numeric($value)) {
+                $value = "{$value}";
             } else {
                 $value = "'" . addslashes($value) . "'";
             }


### PR DESCRIPTION
现有的mysql语句格式化方式有对所有的值都增加了单引号，这种处理会导致一些问题。例如在limit上使用参数会出现如此的格式化结果 SELECT * FROM `t` LIMIT '2','3'。这样会导致语句执行出错