### PR TITLE
添加对数据模型中含下划线字段 set 方法的匹配

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -264,7 +264,11 @@ class Model implements \ArrayAccess, \Iterator, Arrayable,\JsonSerializable
      * @param array $attributes
      *
      * $attributes = [
-     *     'name' => $value
+     *     'userName' => $value
+     * ]
+     * or
+     * $attributes = [
+     *     'user_name' => $value
      * ]
      *
      * @return \Swoft\Db\Model
@@ -272,7 +276,14 @@ class Model implements \ArrayAccess, \Iterator, Arrayable,\JsonSerializable
     public function fill(array $attributes): self
     {
         foreach ($attributes as $name => $value) {
-            $methodName = sprintf('set%s', ucfirst($name));
+            if (1 === preg_match('/_/', $name)) {
+                $nameArr = array_map(function ($row) {
+                    return ucfirst($row);
+                }, explode('_', $name));
+                $methodName = sprintf('set%s', implode('', $nameArr));
+            } else {
+                $methodName = sprintf('set%s', ucfirst($name));
+            }
             if (method_exists($this, $methodName)) {
                 $this->$methodName($value);
             }

--- a/src/Model.php
+++ b/src/Model.php
@@ -276,14 +276,7 @@ class Model implements \ArrayAccess, \Iterator, Arrayable,\JsonSerializable
     public function fill(array $attributes): self
     {
         foreach ($attributes as $name => $value) {
-            if (1 === preg_match('/_/', $name)) {
-                $nameArr = array_map(function ($row) {
-                    return ucfirst($row);
-                }, explode('_', $name));
-                $methodName = sprintf('set%s', implode('', $nameArr));
-            } else {
-                $methodName = sprintf('set%s', ucfirst($name));
-            }
+            $methodName = StringHelper::camel(sprintf('set_%s', $name));
             if (method_exists($this, $methodName)) {
                 $this->$methodName($value);
             }

--- a/src/Model.php
+++ b/src/Model.php
@@ -268,6 +268,10 @@ class Model implements \ArrayAccess, \Iterator, Arrayable,\JsonSerializable
      * ]
      * or
      * $attributes = [
+     *     'UserName' => $value
+     * ]
+     * or
+     * $attributes = [
      *     'user_name' => $value
      * ]
      *
@@ -276,7 +280,10 @@ class Model implements \ArrayAccess, \Iterator, Arrayable,\JsonSerializable
     public function fill(array $attributes): self
     {
         foreach ($attributes as $name => $value) {
-            $methodName = StringHelper::camel(sprintf('set_%s', $name));
+            if (1 === preg_match('/_/', $name)) {
+                $name = StringHelper::camel($name);
+            }
+            $methodName = sprintf('set%s', ucfirst($name));
             if (method_exists($this, $methodName)) {
                 $this->$methodName($value);
             }


### PR DESCRIPTION
由于表字段多词情况下，大家都采取多词下划线分割。导致一些用户在使用 `fill()` 方法时想当然地按照表字段传值，导致最终找不到对应的 `setXxx` 方法，造成按照官方示例，我传值了没效果。

官方 demo 都是单个词的字段，对于多个词的用户不看源码确实有此需要。

我就是在这耗费了些时间。

希望官方组添加此功能，使得多词下划线分割的表字段也能找到对应的 `set` 方法。